### PR TITLE
Add Alberta public keys

### DIFF
--- a/src/issuers.js
+++ b/src/issuers.js
@@ -99,6 +99,16 @@ const issuers = [
         y: "ai71citYuk72ldpGiwRZ0NfZGJPzKZBVulaUv_74IjY" },
     ]
   },
+  {
+    id: "ca.ab",
+    iss: "https://covidrecords.alberta.ca/smarthealth/issuer",
+    keys: [
+      { kid: "JoO-sJHpheZboXdsUK4NtfulfvpiN1GlTdNnXN3XAnM",
+        alg: "ES256", kty: "EC", crv: "P-256", use: "sig",
+        x: "GsriV0gunQpl2X9KgrDZ4EDCtIdfOmdzhdlosWrMqKk",
+        y: "S99mZMCcJRsn662RaAmk_elvGiUs8IvSA7qBh04kaw0" },
+    ]
+  },
 ];
 
 module.exports = {


### PR DESCRIPTION
This pull request adds the AB public keys for their new QR codes.

Alberta's public keys should be available at their [issuer URL](https://covidrecords.alberta.ca/smarthealth/issuer/.well-known/jwks.json), but the keys are not up yet. However, a user on Reddit ([u/YegThrowawayWasTaken](https://reddit.com/user/YegThrowawayWasTaken)) found the public keys embedded in [this site file](https://covidrecords.alberta.ca/main.8cf52f6339fa92fe71cf.js) (look for publicSmartHealthKey variable).

I have confirmed these keys do verify my Alberta QR code and a few others. 